### PR TITLE
fix: audio transcription file cleanup and error handling

### DIFF
--- a/audio_transcription/fast_transcriber.py
+++ b/audio_transcription/fast_transcriber.py
@@ -12,22 +12,21 @@ metadata = sieve.Metadata(
     readme=open("README.md", "r").read(),
 )
 
+
 @sieve.function(
     name="speech_transcriber",
     python_packages=[
         "librosa==0.8.0",
         "soundfile==0.12.1",
         "ffmpeg-python==0.2.0",
-        "numpy==1.19.4"
+        "numpy==1.19.4",
     ],
-    system_packages=[
-        "ffmpeg"
-    ],
+    system_packages=["ffmpeg"],
     environment_variables=[
-        sieve.Env(name="min_silence_length", default= 0.8),
-        sieve.Env(name="min_segment_length", default= 30.0)
+        sieve.Env(name="min_silence_length", default=0.8),
+        sieve.Env(name="min_segment_length", default=30.0),
     ],
-    metadata=metadata
+    metadata=metadata,
 )
 def audio_split_by_silence(file: sieve.Audio):
     import os
@@ -36,11 +35,11 @@ def audio_split_by_silence(file: sieve.Audio):
     import numpy as np
     import soundfile as sf
     import requests
+
     min_silence_length = float(os.getenv("min_silence_length"))
     min_segment_length = float(os.getenv("min_segment_length"))
     from typing import Iterator
     import re
-
 
     def split_silences(
         path: str, min_segment_length: float = 30.0, min_silence_length: float = 0.8
@@ -82,7 +81,6 @@ def audio_split_by_silence(file: sieve.Audio):
                 cur_start = split_at
                 num_segments += 1
 
-
         if duration > cur_start:
             yield cur_start, duration
             num_segments += 1
@@ -91,22 +89,30 @@ def audio_split_by_silence(file: sieve.Audio):
     count = 0
     audio_path = file.path
     whisperx = sieve.function.get("sieve/whisperx")
-    
+
     # create a temporary directory to store the audio files
     import tempfile
     import os
     import shutil
+
     temp_dir = tempfile.mkdtemp()
     import concurrent.futures
+
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
 
     def process_segment(segment):
         start_time, end_time = segment
         print(f"Splitting {audio_path} from {start_time} to {end_time}")
-        whisperx_job = whisperx.push(sieve.Audio(path=audio_path, start_time=start_time, end_time=end_time))
+        whisperx_job = whisperx.push(
+            sieve.Audio(path=audio_path, start_time=start_time, end_time=end_time)
+        )
         return whisperx_job
 
-    segments = split_silences(audio_path, min_silence_length=min_silence_length, min_segment_length=min_segment_length)
+    segments = split_silences(
+        audio_path,
+        min_silence_length=min_silence_length,
+        min_segment_length=min_segment_length,
+    )
     if not segments:
         segments.append(whisperx.push(sieve.Audio(path=audio_path)))
 

--- a/translation/seamless_text_to_text/model.py
+++ b/translation/seamless_text_to_text/model.py
@@ -10,14 +10,13 @@ model_metadata = sieve.Metadata(
     readme=open("README.md", "r").read(),
 )
 
+
 ### Text 2 Text
 @sieve.Model(
-    name="seamless_text2text", 
+    name="seamless_text2text",
     machine_type="a100",
     gpu=True,
-    python_packages=[
-        "git+https://github.com/facebookresearch/seamless_communication"
-    ],
+    python_packages=["git+https://github.com/facebookresearch/seamless_communication"],
     system_packages=[
         "libsndfile1",
         "libopenblas-base",
@@ -29,7 +28,7 @@ model_metadata = sieve.Metadata(
         # "wget -q https://huggingface.co/facebook/seamless-m4t-large/resolve/main/multitask_unity_large.pt -O /root/.cache/torch/hub/fairseq2/assets/checkpoints/43b8b74ddb6b78486fb47754/multitask_unity_large.pt",
     ],
     cuda_version="11.8",
-    metadata=model_metadata
+    metadata=model_metadata,
 )
 class SeamlessText2Text:
     def __setup__(self):
@@ -38,7 +37,9 @@ class SeamlessText2Text:
         import torchaudio
 
         # Initialize a Translator object with a multitask model, vocoder on the GPU.
-        self.translator = Translator("seamlessM4T_large", "vocoder_36langs", torch.device("cuda"), torch.float16)
+        self.translator = Translator(
+            "seamlessM4T_large", "vocoder_36langs", torch.device("cuda"), torch.float16
+        )
 
     def __predict__(self, text: str, source_language: str, target_language: str) -> str:
         """
@@ -49,7 +50,9 @@ class SeamlessText2Text:
         """
 
         # Translate the text to desired language in text
-        translated_text, _, _ = self.translator.predict(text, "t2tt", target_language, src_lang=source_language)
+        translated_text, _, _ = self.translator.predict(
+            text, "t2tt", target_language, src_lang=source_language
+        )
 
         # Convert text to string
         translated_text = str(translated_text)

--- a/video_transcript_analysis/main.py
+++ b/video_transcript_analysis/main.py
@@ -1,7 +1,8 @@
-#TODO: change this thing
+# TODO: change this thing
 
 import sieve
 from typing import Dict, List
+import tempfile
 
 metadata = sieve.Metadata(
     title="Video Transcript Analysis",
@@ -17,35 +18,48 @@ metadata = sieve.Metadata(
 
 @sieve.function(
     name="video_transcript_analyzer",
-    python_packages=[
-        "gpt-json"
-    ],
-    system_packages=[
-        "ffmpeg"
-    ],
+    python_packages=["gpt-json"],
+    system_packages=["ffmpeg"],
     python_version="3.10",
     environment_variables=[
         sieve.Env(name="OPENAI_API_KEY", description="OpenAI API Key"),
-        sieve.Env(name="NUM_TAGS", description="Number of tags to generate", default="5"),
-        sieve.Env(name="MAX_SUMMARY_SENTENCES", description="Number of sentences to summarize", default="5"),
-        sieve.Env(name="MAX_TITLE_WORDS", description="Max number of words in title", default="10"),
+        sieve.Env(
+            name="NUM_TAGS", description="Number of tags to generate", default="5"
+        ),
+        sieve.Env(
+            name="MAX_SUMMARY_SENTENCES",
+            description="Number of sentences to summarize",
+            default="5",
+        ),
+        sieve.Env(
+            name="MAX_TITLE_WORDS",
+            description="Max number of words in title",
+            default="10",
+        ),
     ],
-    metadata=metadata
+    metadata=metadata,
 )
 def analyze_transcript(file: sieve.Video) -> Dict:
     print("running ffmpeg to convert video to audio")
     # video to audio
     import subprocess
     import os
+    import uuid
+
+    id = str(uuid.uuid4())
+    audio_path = "temp" + id + ".wav"
     try:
-        audio_path = 'temp.wav'
         subprocess.run(["ffmpeg", "-i", file.path, audio_path, "-y"])
     except Exception as e:
-        raise Exception("Failed to extract audio from video. Make sure video has audio.")
-    
+        raise Exception(
+            "Failed to extract audio from video. Make sure video has audio."
+        )
+
     if not os.path.isfile(audio_path):
-        raise Exception("Failed to extract audio from video. Make sure video has audio.")
-    
+        raise Exception(
+            "Failed to extract audio from video. Make sure video has audio."
+        )
+
     print("ffmpeg finished")
     print("running speech to text")
     # audio to text
@@ -69,10 +83,7 @@ def analyze_transcript(file: sieve.Video) -> Dict:
         yield {"chapters": []}
         return
 
-    import time
-    overall_start_time = time.time()
     import os
-    import json
     import asyncio
 
     from transcript_analysis import description_runner, chapter_runner
@@ -81,7 +92,14 @@ def analyze_transcript(file: sieve.Video) -> Dict:
     max_num_words = int(os.getenv("MAX_TITLE_WORDS", 10))
     num_tags = int(os.getenv("NUM_TAGS", 5))
     print("running description runner")
-    summary, title, tags = asyncio.run(description_runner(transcript, max_num_sentences=max_num_sentences, max_num_words= max_num_words, num_tags=num_tags))
+    summary, title, tags = asyncio.run(
+        description_runner(
+            transcript,
+            max_num_sentences=max_num_sentences,
+            max_num_words=max_num_words,
+            num_tags=num_tags,
+        )
+    )
     print("finished description runner")
     yield {"summary": summary}
     yield {"title": title}
@@ -94,3 +112,6 @@ def analyze_transcript(file: sieve.Video) -> Dict:
     for chapter in chapters:
         out_list.append({"title": chapter.title, "start_time": chapter.start_time})
     yield {"chapters": out_list}
+
+    if os.path.exists(audio_path):
+        os.remove(audio_path)


### PR DESCRIPTION
Fix audio transcription file: 

Problem: 
The filename `temp.mp4` was reused and if there is an ffmpeg error on the current job, the function will not throw and error and use the audio from the previous job. Able to reproduce this by setting min replica = 1, running a job with audio, then running a job without audio. You will see the job without audio have the same transcript as the job with audio. 

Fix: 
For each job create a unique name for the audio file and clean up after the job. 

Testing:
Verified that the correct error `Exception: Failed to extract audio from video. Make sure video has audio` is thrown every time on a video without audio and normal transcriptions are still working. 

 Note: 
I ran formatting on the directories that i changed, but i used comments to mark the actual code changes that i made. 